### PR TITLE
Let NETSTATS_SERVER contain full link

### DIFF
--- a/group_vars/all.network
+++ b/group_vars/all.network
@@ -20,7 +20,7 @@ region: "us-west-2"
 
 NODE_PWD: "node.pwd" # don't change this one
 NODE_SOURCE_DEB: "https://deb.nodesource.com/node_8.x"
-PARITY_BIN_LOC: "https://github.com/oraclesorg/binary-releases/releases/download/1.8.2/parity"
+PARITY_BIN_LOC: "https://github.com/oraclesorg/binary-releases/releases/download/1.8.3/parity"
 
 SCRIPTS_OWNER_BRANCH: "master"
 SCRIPTS_VALIDATOR_BRANCH: "master"
@@ -29,7 +29,7 @@ TEMPLATES_BRANCH: "dev-mainnet"
 GENESIS_BRANCH: "master"
 
 OWNER_ADDRESS: "0xdd0bb0e2a1594240fed0c2f2c17c1e9ab4f87126"
-NETSTATS_SERVER: "34.215.172.88"
+NETSTATS_SERVER: "https://red-netstats.poa.network"
 TX_GAS_LIMIT: "6700000"
 
 #bootnode

--- a/roles/oracles-netstats/templates/app.json.j2
+++ b/roles/oracles-netstats/templates/app.json.j2
@@ -15,7 +15,7 @@
             "NODE_ENV"         : "production",
             "RPC_HOST"         : "localhost",
             "RPC_PORT"         : "8545",
-            "LISTENING_PORT"   : "30300",
+            "LISTENING_PORT"   : "30303",
             "INSTANCE_NAME"    : "{{ NODE_FULLNAME }}",
             "CONTACT_DETAILS"  : "{{ NODE_ADMIN_EMAIL }}",
             "WS_SERVER"        : "{{ NETSTATS_SERVER }}",

--- a/roles/oracles-netstats/templates/app.json.j2
+++ b/roles/oracles-netstats/templates/app.json.j2
@@ -18,7 +18,7 @@
             "LISTENING_PORT"   : "30300",
             "INSTANCE_NAME"    : "{{ NODE_FULLNAME }}",
             "CONTACT_DETAILS"  : "{{ NODE_ADMIN_EMAIL }}",
-            "WS_SERVER"        : "http://{{ NETSTATS_SERVER }}:3000",
+            "WS_SERVER"        : "{{ NETSTATS_SERVER }}",
             "WS_SECRET"        : "{{ NETSTATS_SECRET }}",
             "VERBOSITY"        : 2
         }

--- a/roles/oracles-parity/templates/app.json.j2
+++ b/roles/oracles-parity/templates/app.json.j2
@@ -15,10 +15,10 @@
             "NODE_ENV"         : "production",
             "RPC_HOST"         : "localhost",
             "RPC_PORT"         : "8545",
-            "LISTENING_PORT"   : "30300",
+            "LISTENING_PORT"   : "30303",
             "INSTANCE_NAME"    : "{{ NODE_FULLNAME }}",
             "CONTACT_DETAILS"  : "{{ NODE_ADMIN_EMAIL }}",
-            "WS_SERVER"        : "http://{{ NETSTATS_SERVER }}:3000",
+            "WS_SERVER"        : "{{ NETSTATS_SERVER }}",
             "WS_SECRET"        : "{{ NETSTATS_SECRET }}",
             "VERBOSITY"        : 2
         }

--- a/site.yml
+++ b/site.yml
@@ -49,7 +49,7 @@
 - hosts: netstat
   vars:
     PROXY_PORT: "3000"
-    NETSTATS_SERVER: "localhost"
+    NETSTATS_SERVER: "http://localhost:3000"
     username: "netstat"
     users:
       - name: "netstat"


### PR DESCRIPTION
In case custom SSL certificates are installed, it would be simpler to provide full link to public address of the netstats server (https://....) with correct protocol and without port number.