### PR TITLE
Fix possibility to launch multiple VMs on EC2 (178 issue)

### DIFF
--- a/aws/bootnode.yml
+++ b/aws/bootnode.yml
@@ -18,11 +18,6 @@
           from_port: 22
           to_port: 22
           cidr_ip: 0.0.0.0/0
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
   tags: bootnode
 
 

--- a/aws/bootnode.yml
+++ b/aws/bootnode.yml
@@ -32,7 +32,7 @@
   tasks:
     - name: Launch instance
       ec2:
-        id: "{{ bootnode_instance_name }}"
+        id: "{{ bootnode_instance_name }}-{{ item }}"
         ec2_access_key: "{{ access_key }}"
         ec2_secret_key: "{{ secret_key }}"
         key_name: "{{ awskeypair_name }}"
@@ -46,15 +46,14 @@
         vpc_subnet_id: "{{ vpc_subnet_id }}"
         volumes: "{{ volumes }}"
         assign_public_ip: yes
-      with_sequence:
-        count: "{{ bootnode_count_instances }}"
+      with_sequence: "count={{ bootnode_count_instances }}"
       register:   ec2
     - name: Add new instance to host group
-      add_host: hostname={{ item.public_ip }} groupname=launched
-      with_items: "{{ ec2.instances }}"
+      add_host: hostname={{ item.instances[0].public_ip }} groupname=launched
+      with_items: "{{ ec2.results }}"
     - name: Wait for SSH to come up
-      wait_for: host={{ item.public_ip }} port=22 delay=90 timeout=320 state=started
-      with_items: "{{ ec2.instances }}"
+      wait_for: host={{ item.instances[0].public_ip }} port=22 delay=90 timeout=320 state=started
+      with_items: "{{ ec2.results }}"
       when: ec2.changed
   tags: bootnode
 

--- a/aws/bootnode.yml
+++ b/aws/bootnode.yml
@@ -37,16 +37,17 @@
         ec2_secret_key: "{{ secret_key }}"
         key_name: "{{ awskeypair_name }}"
         instance_tags:
-          Name: "{{ bootnode_instance_name }}"
+          Name: "{{ bootnode_instance_name }}-{{ item }}"
         group: "{{ bootnode_security_group }}"
         instance_type: "{{ bootnode_instance_type }}"
         image: "{{ image }}"
-        count: "{{ bootnode_count_instances }}"
         wait: yes
         region: "{{ region }}"
         vpc_subnet_id: "{{ vpc_subnet_id }}"
         volumes: "{{ volumes }}"
         assign_public_ip: yes
+      with_sequence:
+        count: "{{ bootnode_count_instances }}"
       register:   ec2
     - name: Add new instance to host group
       add_host: hostname={{ item.public_ip }} groupname=launched

--- a/aws/explorer.yml
+++ b/aws/explorer.yml
@@ -32,7 +32,7 @@
   tasks:
     - name: Launch instance
       ec2:
-        id: "{{ explorer_instance_name }}"
+        id: "{{ explorer_instance_name }}-{{ item }}"
         ec2_access_key: "{{ access_key }}"
         ec2_secret_key: "{{ secret_key }}"
         key_name: "{{ awskeypair_name }}"
@@ -46,15 +46,14 @@
         vpc_subnet_id: "{{ vpc_subnet_id }}"
         volumes: "{{ volumes }}"
         assign_public_ip: yes
-      with_sequence:
-        count: "{{ explorer_count_instances }}"
+      with_sequence: "count={{ explorer_count_instances }}"
       register:   ec2
     - name: Add new instance to host group
-      add_host: hostname={{ item.public_ip }} groupname=launched
-      with_items: "{{ ec2.instances }}"
+      add_host: hostname={{ item.instances[0].public_ip }} groupname=launched
+      with_items: "{{ ec2.results }}"
     - name: Wait for SSH to come up
-      wait_for: host={{ item.public_ip }} port=22 delay=90 timeout=320 state=started
-      with_items: "{{ ec2.instances }}"
+      wait_for: host={{ item.instances[0].public_ip }} port=22 delay=90 timeout=320 state=started
+      with_items: "{{ ec2.results }}"
       when: ec2.changed
 tags: explorer
 

--- a/aws/explorer.yml
+++ b/aws/explorer.yml
@@ -18,11 +18,6 @@
           from_port: 22
           to_port: 22
           cidr_ip: 0.0.0.0/0
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
   tags: explorer
 
 

--- a/aws/explorer.yml
+++ b/aws/explorer.yml
@@ -37,16 +37,17 @@
         ec2_secret_key: "{{ secret_key }}"
         key_name: "{{ awskeypair_name }}"
         instance_tags:
-          Name: "{{ explorer_instance_name }}"
+          Name: "{{ explorer_instance_name }}-{{ item }}"
         group: "{{ explorer_security_group }}"
         instance_type: "{{ explorer_instance_type }}"
         image: "{{ image }}"
-        count: "{{ explorer_count_instances }}"
         wait: yes
         region: "{{ region }}"
         vpc_subnet_id: "{{ vpc_subnet_id }}"
         volumes: "{{ volumes }}"
         assign_public_ip: yes
+      with_sequence:
+        count: "{{ explorer_count_instances }}"
       register:   ec2
     - name: Add new instance to host group
       add_host: hostname={{ item.public_ip }} groupname=launched

--- a/aws/moc.yml
+++ b/aws/moc.yml
@@ -18,11 +18,6 @@
           from_port: 22
           to_port: 22
           cidr_ip: 0.0.0.0/0
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
   tags: moc
 
 

--- a/aws/moc.yml
+++ b/aws/moc.yml
@@ -37,16 +37,17 @@
         ec2_secret_key: "{{ secret_key }}"
         key_name: "{{ awskeypair_name }}"
         instance_tags:
-          Name: "{{ moc_instance_name }}"
+          Name: "{{ moc_instance_name }}-{{ item }}"
         group: "{{ moc_security_group }}"
         instance_type: "{{ moc_instance_type }}"
         image: "{{ image }}"
-        count: "{{ moc_count_instances }}"
         wait: yes
         region: "{{ region }}"
         vpc_subnet_id: "{{ vpc_subnet_id }}"
         volumes: "{{ volumes }}"
         assign_public_ip: yes
+      with_sequence:
+        count: "{{ explorer_count_instances }}"
       register:   ec2
     - name: Add new instance to host group
       add_host: hostname={{ item.public_ip }} groupname=launched

--- a/aws/moc.yml
+++ b/aws/moc.yml
@@ -32,7 +32,7 @@
   tasks:
     - name: Launch instance
       ec2:
-        id: "{{ moc_instance_name }}"
+        id: "{{ moc_instance_name }}-{{ item }}"
         ec2_access_key: "{{ access_key }}"
         ec2_secret_key: "{{ secret_key }}"
         key_name: "{{ awskeypair_name }}"
@@ -46,15 +46,14 @@
         vpc_subnet_id: "{{ vpc_subnet_id }}"
         volumes: "{{ volumes }}"
         assign_public_ip: yes
-      with_sequence:
-        count: "{{ explorer_count_instances }}"
+      with_sequence: "count={{ explorer_count_instances }}"
       register:   ec2
     - name: Add new instance to host group
-      add_host: hostname={{ item.public_ip }} groupname=launched
-      with_items: "{{ ec2.instances }}"
+      add_host: hostname={{ item.instances[0].public_ip }} groupname=launched
+      with_items: "{{ ec2.results }}"
     - name: Wait for SSH to come up
-      wait_for: host={{ item.public_ip }} port=22 delay=90 timeout=320 state=started
-      with_items: "{{ ec2.instances }}"
+      wait_for: host={{ item.instances[0].public_ip }} port=22 delay=90 timeout=320 state=started
+      with_items: "{{ ec2.results }}"
       when: ec2.changed
   tags: moc
 

--- a/aws/netstat.yml
+++ b/aws/netstat.yml
@@ -37,16 +37,17 @@
         ec2_secret_key: "{{ secret_key }}"
         key_name: "{{ awskeypair_name }}"
         instance_tags:
-          Name: "{{ netstat_instance_name }}"
+          Name: "{{ netstat_instance_name }}-{{ item }}"
         group: "{{ netstat_security_group }}"
         instance_type: "{{ netstat_instance_type }}"
         image: "{{ image }}"
-        count: "{{ netstat_count_instances }}"
         wait: yes
         region: "{{ region }}"
         vpc_subnet_id: "{{ vpc_subnet_id }}"
         volumes: "{{ volumes }}"
         assign_public_ip: yes
+      with_items:
+        count: "{{ netstat_count_instances }}"
       register:   ec2
     - name: Add new instance to host group
       add_host: hostname={{ item.public_ip }} groupname=launched

--- a/aws/netstat.yml
+++ b/aws/netstat.yml
@@ -32,7 +32,7 @@
   tasks:
     - name: Launch instance
       ec2:
-        id: "{{ netstat_instance_name }}"
+        id: "{{ netstat_instance_name }}-{{ item }}"
         ec2_access_key: "{{ access_key }}"
         ec2_secret_key: "{{ secret_key }}"
         key_name: "{{ awskeypair_name }}"
@@ -46,15 +46,14 @@
         vpc_subnet_id: "{{ vpc_subnet_id }}"
         volumes: "{{ volumes }}"
         assign_public_ip: yes
-      with_items:
-        count: "{{ netstat_count_instances }}"
+      with_items: "count={{ netstat_count_instances }}"
       register:   ec2
     - name: Add new instance to host group
-      add_host: hostname={{ item.public_ip }} groupname=launched
-      with_items: "{{ ec2.instances }}"
+      add_host: hostname={{ item.instances[0].public_ip }} groupname=launched
+      with_items: "{{ ec2.results }}"
     - name: Wait for SSH to come up
-      wait_for: host={{ item.public_ip }} port=22 delay=90 timeout=320 state=started
-      with_items: "{{ ec2.instances }}"
+      wait_for: host={{ item.instances[0].public_ip }} port=22 delay=90 timeout=320 state=started
+      with_items: "{{ ec2.results }}"
       when: ec2.changed
   tags: netstat
 

--- a/aws/netstat.yml
+++ b/aws/netstat.yml
@@ -18,11 +18,6 @@
           from_port: 22
           to_port: 22
           cidr_ip: 0.0.0.0/0
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
   tags: netstat
 
 

--- a/aws/roles/bootnode-access/tasks/ec2.yml
+++ b/aws/roles/bootnode-access/tasks/ec2.yml
@@ -10,23 +10,6 @@
       purge_rules: true
       vpc_id: "{{ vpc_id }}"
 
-- name: Allow outbound traffic
-  delegate_to: localhost
-  ec2_group:
-      ec2_access_key: "{{ access_key }}"
-      ec2_secret_key: "{{ secret_key }}"
-      name: "{{ bootnode_security_group }}"
-      description: "Default security group"
-      region: "{{ region }}"
-      purge_rules_egress: false
-      purge_rules: false
-      vpc_id: "{{ vpc_id }}"
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
-
 - name: Add ssh access
   delegate_to: localhost
   ec2_group:

--- a/aws/roles/explorer-access/tasks/ec2.yml
+++ b/aws/roles/explorer-access/tasks/ec2.yml
@@ -10,23 +10,6 @@
       purge_rules: true
       vpc_id: "{{ vpc_id }}"
 
-- name: Allow outbound traffic
-  delegate_to: localhost
-  ec2_group:
-      ec2_access_key: "{{ access_key }}"
-      ec2_secret_key: "{{ secret_key }}"
-      name: "{{ explorer_security_group }}"
-      description: "Default security group"
-      region: "{{ region }}"
-      purge_rules_egress: false
-      purge_rules: false
-      vpc_id: "{{ vpc_id }}"
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
-
 - name: Add ssh access
   delegate_to: localhost
   ec2_group:

--- a/aws/roles/moc-access/tasks/ec2.yml
+++ b/aws/roles/moc-access/tasks/ec2.yml
@@ -10,23 +10,6 @@
       purge_rules: true
       vpc_id: "{{ vpc_id }}"
 
-- name: Allow outbound traffic
-  delegate_to: localhost
-  ec2_group:
-      ec2_access_key: "{{ access_key }}"
-      ec2_secret_key: "{{ secret_key }}"
-      name: "{{ moc_security_group }}"
-      description: "Default security group"
-      region: "{{ region }}"
-      purge_rules_egress: false
-      purge_rules: false
-      vpc_id: "{{ vpc_id }}"
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
-
 - name: Add ssh access
   delegate_to: localhost
   ec2_group:

--- a/aws/roles/netstat-access/tasks/ec2.yml
+++ b/aws/roles/netstat-access/tasks/ec2.yml
@@ -10,23 +10,6 @@
       purge_rules: true
       vpc_id: "{{ vpc_id }}"
 
-- name: Allow outbound traffic
-  delegate_to: localhost
-  ec2_group:
-      ec2_access_key: "{{ access_key }}"
-      ec2_secret_key: "{{ secret_key }}"
-      name: "{{ netstat_security_group }}"
-      description: "Default security group"
-      region: "{{ region }}"
-      purge_rules_egress: false
-      purge_rules: false
-      vpc_id: "{{ vpc_id }}"
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
-
 - name: Add ssh access
   delegate_to: localhost
   ec2_group:

--- a/aws/roles/validator-access/tasks/ec2.yml
+++ b/aws/roles/validator-access/tasks/ec2.yml
@@ -10,23 +10,6 @@
       purge_rules: true
       vpc_id: "{{ vpc_id }}"
 
-- name: Allow outbound traffic
-  delegate_to: localhost
-  ec2_group:
-      ec2_access_key: "{{ access_key }}"
-      ec2_secret_key: "{{ secret_key }}"
-      name: "{{ validator_security_group }}"
-      description: "Default security group"
-      region: "{{ region }}"
-      purge_rules_egress: false
-      purge_rules: false
-      vpc_id: "{{ vpc_id }}"
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
-
 - name: Add ssh access
   delegate_to: localhost
   ec2_group:

--- a/aws/validator.yml
+++ b/aws/validator.yml
@@ -37,16 +37,17 @@
         ec2_secret_key: "{{ secret_key }}"
         key_name: "{{ awskeypair_name }}"
         instance_tags:
-          Name: "{{ validator_instance_name }}"
+          Name: "{{ validator_instance_name }}-{{ item }}"
         group: "{{ validator_security_group }}"
         instance_type: "{{ validator_instance_type }}"
         image: "{{ image }}"
-        count: "{{ validator_count_instances }}"
         wait: yes
         region: "{{ region }}"
         vpc_subnet_id: "{{ vpc_subnet_id }}"
         volumes: "{{ volumes }}"
         assign_public_ip: yes
+      with_items:
+        count: "{{ validator_count_instances }}"
       register:   ec2
     - name: Add new instance to host group
       add_host: hostname={{ item.public_ip }} groupname=launched

--- a/aws/validator.yml
+++ b/aws/validator.yml
@@ -18,11 +18,6 @@
           from_port: 22
           to_port: 22
           cidr_ip: 0.0.0.0/0
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
   tags: validator
 
 

--- a/aws/validator.yml
+++ b/aws/validator.yml
@@ -32,7 +32,7 @@
   tasks:
     - name: Launch instance
       ec2:
-        id: "{{ validator_instance_name }}"
+        id: "{{ validator_instance_name }}-{{ item }}"
         ec2_access_key: "{{ access_key }}"
         ec2_secret_key: "{{ secret_key }}"
         key_name: "{{ awskeypair_name }}"
@@ -46,15 +46,14 @@
         vpc_subnet_id: "{{ vpc_subnet_id }}"
         volumes: "{{ volumes }}"
         assign_public_ip: yes
-      with_items:
-        count: "{{ validator_count_instances }}"
+      with_items: "count={{ validator_count_instances }}"
       register:   ec2
     - name: Add new instance to host group
-      add_host: hostname={{ item.public_ip }} groupname=launched
-      with_items: "{{ ec2.instances }}"
+      add_host: hostname={{ item.instances[0].public_ip }} groupname=launched
+      with_items: "{{ ec2.results }}"
     - name: Wait for SSH to come up
-      wait_for: host={{ item.public_ip }} port=22 delay=90 timeout=320 state=started
-      with_items: "{{ ec2.instances }}"
+      wait_for: host={{ item.instances[0].public_ip }} port=22 delay=90 timeout=320 state=started
+      with_items: "{{ ec2.results }}"
       when: ec2.changed
   tags: validator
 


### PR DESCRIPTION
I've revisioned code during investigation of #178 issue and found that we can replace module-native "count" parameter with the ansible-native "with_sequence" parameter. The downside of that approach in fact that VMs will be launched one by one and not in parallel. However, the other only option for now is to remove ID field, which is much worse, since created VMs will become obscure soon.